### PR TITLE
Move from BroadcastChannel to Channel

### DIFF
--- a/app/src/main/java/se/hellsoft/android/instantsearchdemo/MainActivity.kt
+++ b/app/src/main/java/se/hellsoft/android/instantsearchdemo/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : AppCompatActivity() {
 
         binding.searchText.doAfterTextChanged { editable ->
             lifecycleScope.launch {
-                viewModel.queryChannel.send(editable.toString())
+                viewModel.onSearchTextChanged(editable.toString())
             }
         }
     }

--- a/app/src/main/java/se/hellsoft/android/instantsearchdemo/SearchViewModel.kt
+++ b/app/src/main/java/se/hellsoft/android/instantsearchdemo/SearchViewModel.kt
@@ -6,10 +6,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.mapLatest
 
@@ -31,13 +30,13 @@ class SearchViewModel(
 
     @ExperimentalCoroutinesApi
     @VisibleForTesting
-    internal val queryChannel = BroadcastChannel<String>(Channel.CONFLATED)
+    internal val queryChannel = Channel<String>(Channel.CONFLATED)
 
     @FlowPreview
     @ExperimentalCoroutinesApi
     @VisibleForTesting
     internal val internalSearchResult = queryChannel
-        .asFlow()
+        .consumeAsFlow()
         .debounce(SEARCH_DELAY_MS)
         .mapLatest {
             try {

--- a/app/src/main/java/se/hellsoft/android/instantsearchdemo/SearchViewModel.kt
+++ b/app/src/main/java/se/hellsoft/android/instantsearchdemo/SearchViewModel.kt
@@ -1,7 +1,6 @@
 package se.hellsoft.android.instantsearchdemo
 
 import android.content.res.AssetManager
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
@@ -29,13 +28,11 @@ class SearchViewModel(
     }
 
     @ExperimentalCoroutinesApi
-    @VisibleForTesting
-    internal val queryChannel = Channel<String>(Channel.CONFLATED)
+    private val queryChannel = Channel<String>(Channel.CONFLATED)
 
     @FlowPreview
     @ExperimentalCoroutinesApi
-    @VisibleForTesting
-    internal val internalSearchResult = queryChannel
+    private val internalSearchResult = queryChannel
         .consumeAsFlow()
         .debounce(SEARCH_DELAY_MS)
         .mapLatest {
@@ -68,6 +65,9 @@ class SearchViewModel(
     @FlowPreview
     @ExperimentalCoroutinesApi
     val searchResult = internalSearchResult.asLiveData()
+
+    @ExperimentalCoroutinesApi
+    suspend fun onSearchTextChanged(text: String) = queryChannel.send(text)
 
     class Factory(private val assets: AssetManager, private val dispatcher: CoroutineDispatcher) :
         ViewModelProvider.NewInstanceFactory() {

--- a/app/src/test/java/se/hellsoft/android/instantsearchdemo/SearchViewModelTest.kt
+++ b/app/src/test/java/se/hellsoft/android/instantsearchdemo/SearchViewModelTest.kt
@@ -4,9 +4,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -40,7 +37,6 @@ class SearchViewModelTest {
     fun testInstantSearch() = mainDispatcher.runBlockingTest {
         // GIVEN
         val fakeApi = FakeApi()
-        val actualQueries = mutableListOf<String>()
         val expectedQueries = listOf("aa", "bbb", "ccc", "ddd actual query")
 
         val subject = SearchViewModel(
@@ -50,19 +46,13 @@ class SearchViewModelTest {
 
         // start collecting flows in a new coroutine
         val collectParent = launch {
-            // collect the flow to trigger the debouncing behavior
-            subject.internalSearchResult.launchIn(this)
-
-            // make sure we're actually sending all queries through – since we're modifying
-            // execution order with TestCoroutineDispatcher. This is just a sanity check.
-            subject.queryChannel.consumeAsFlow().mapLatest { query ->
-                actualQueries.add(query)
-            }.launchIn(this)
+            // observe the livedata to collect the flow to trigger the debouncing behavior
+            subject.searchResult.observeForever {}
         }
 
         // WHEN
         for (query in expectedQueries) {
-            subject.queryChannel.send(query)
+            subject.onSearchTextChanged(query)
             advanceTimeBy(35) // make sure a small time advance still keeps debouncing
         }
 
@@ -74,7 +64,6 @@ class SearchViewModelTest {
 
         // THEN
         assert(fakeApi.actualQueries == listOf("ddd actual query")) { "Only saw one search" }
-        assert(actualQueries == expectedQueries) { "all queries were sent, then debounced" }
     }
 
     class FakeApi : SearchApi {

--- a/app/src/test/java/se/hellsoft/android/instantsearchdemo/SearchViewModelTest.kt
+++ b/app/src/test/java/se/hellsoft/android/instantsearchdemo/SearchViewModelTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
@@ -55,7 +55,7 @@ class SearchViewModelTest {
 
             // make sure we're actually sending all queries through – since we're modifying
             // execution order with TestCoroutineDispatcher. This is just a sanity check.
-            subject.queryChannel.asFlow().mapLatest { query ->
+            subject.queryChannel.consumeAsFlow().mapLatest { query ->
                 actualQueries.add(query)
             }.launchIn(this)
         }


### PR DESCRIPTION
Since there’s only one consumer for the channel, we shouldn't really need to use a `BroadcastChannel` there.

The tests had to be updated since we can't `collect` there anymore. And in order to enforce this, the channel isn't exposed from the `ViewModel` anymore, so a couple of other things changed because of that as well.